### PR TITLE
Start Telegram app fullscreen without swiping

### DIFF
--- a/hooks/use-telegram.ts
+++ b/hooks/use-telegram.ts
@@ -75,6 +75,8 @@ interface TelegramWebApp {
     selectionChanged(): void
   }
   expand(): void
+  disableVerticalSwipe(): void
+  enableVerticalSwipe(): void
   close(): void
   ready(): void
   sendData(data: string): void
@@ -122,6 +124,7 @@ export function useTelegram() {
       // Initialize the app
       tg.ready()
       tg.expand()
+      tg.disableVerticalSwipe()
 
       // Set theme colors
       if (tg.themeParams.bg_color) {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -117,7 +117,10 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    @apply h-full overscroll-none;
+  }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground h-full overflow-hidden overscroll-none;
   }
 }


### PR DESCRIPTION
## Summary
- Ensure Telegram mini-app launches expanded and disables vertical swiping
- Prevent page scrolling/overscroll for a stationary fullscreen layout

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689e2d9a9f448323bffd10f528f477b5